### PR TITLE
Add sourcemap support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,51 @@ var nested = require('postcss-nested');
 
 metalsmith.use(postcss([pseudoelements(), nested()]));
 ```
+
+## Sourcemaps
+
+This plugin doesn't generate sourcemaps by default. However, you
+can enable them using several ways.
+
+### Inline sourcemaps
+
+Add `map: true` to the `options` argument to get your
+sourcemaps written into the source file.
+
+```js
+metalsmith.use(postcss([...], {
+  map: true
+}));
+```
+
+Behind the scenes, this resolves to the following:
+
+```js
+metalsmith.use(postcss([...], {
+  map: {
+    inline: true
+  }
+}));
+```
+
+### External sourcemaps
+
+If you don't want to have your files polluted with sourcemaps,
+just set `inline: false`. Using that, you'll get `.map` files
+generated beside your sources.
+
+```js
+metalsmith.use(postcss([...], {
+  map: {
+    inline: false
+  }
+}));
+```
+
+## Test
+
+To run the tests use:
+
+```sh
+npm test
+```

--- a/index.js
+++ b/index.js
@@ -3,20 +3,48 @@ var minimatch = require('minimatch');
 
 module.exports = main;
 
-function main(plugins) {
+function main(plugins, options) {
   var plugins = plugins || [];
+  var options = options || {};
+  var map = normalizeMapOptions(options.map);
 
-  var processor = postcss();
-
-  plugins.forEach(function(plugin) {
-    processor.use(plugin);
-  });
+  var processor = postcss(plugins);
 
   return function (files, metalsmith, done) {
     var styles = Object.keys(files).filter(minimatch.filter("*.css", { matchBase: true }));
-    styles.forEach(function (file, index, arr) {
-      files[file].contents = new Buffer(processor.process(files[file].contents.toString()).css);
+
+    styles.forEach(function (file) {
+      var contents = files[file].contents.toString();
+
+      processor
+        .process(contents, {
+          from: file,
+          to: file,
+          map: map
+        })
+        .then(function (result) {
+          files[file].contents = new Buffer(result.css);
+
+           if (result.map) {
+             files[file + '.map'] = {
+               contents: new Buffer(JSON.stringify(result.map)),
+               mode: files[file].mode,
+               stats: files[file].stats
+             };
+           }
+        });
     });
     done();
   }
+}
+
+function normalizeMapOptions(map) {
+  if (!map) return undefined;
+
+  return {
+    inline: map === true ? true : map.inline,
+    prev: false, // Not implemented yet
+    sourcesContent: undefined,  // Not implemented yet
+    annotation: undefined // Not implemented yet
+  };
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "homepage": "https://github.com/axa-ch/metalsmith-postcss",
   "dependencies": {
     "minimatch": "^2.0.1",
-    "postcss": "^5.0.4"
+    "postcss": "^5.0.4",
+    "promise": "^7.0.4"
   },
   "devDependencies": {
     "assert-dir-equal": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "metalsmith postcss plugin",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "./node_modules/.bin/mocha test --harmony"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -23,5 +23,10 @@
   "dependencies": {
     "minimatch": "^2.0.1",
     "postcss": "^5.0.4"
+  },
+  "devDependencies": {
+    "assert-dir-equal": "^1.0.1",
+    "metalsmith": "^2.1.0",
+    "mocha": "^2.3.3"
   }
 }

--- a/test/fixtures/external-sourcemaps/expected/styles.css
+++ b/test/fixtures/external-sourcemaps/expected/styles.css
@@ -1,0 +1,5 @@
+body {
+  color: peachpuff;
+}
+
+/*# sourceMappingURL=styles.css.map */

--- a/test/fixtures/external-sourcemaps/expected/styles.css.map
+++ b/test/fixtures/external-sourcemaps/expected/styles.css.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":["styles.css"],"names":[],"mappings":"AAAA;EACE,iBAAiB;CAClB","file":"styles.css","sourcesContent":["body {\n  color: peachpuff;\n}\n"]}

--- a/test/fixtures/external-sourcemaps/src/styles.css
+++ b/test/fixtures/external-sourcemaps/src/styles.css
@@ -1,0 +1,3 @@
+body {
+  color: peachpuff;
+}

--- a/test/fixtures/inline-sourcemaps/expected/styles.css
+++ b/test/fixtures/inline-sourcemaps/expected/styles.css
@@ -1,0 +1,5 @@
+body {
+  color: peachpuff;
+}
+
+/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInN0eWxlcy5jc3MiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUE7RUFDRSxpQkFBaUI7Q0FDbEIiLCJmaWxlIjoic3R5bGVzLmNzcyIsInNvdXJjZXNDb250ZW50IjpbImJvZHkge1xuICBjb2xvcjogcGVhY2hwdWZmO1xufVxuIl19 */

--- a/test/fixtures/inline-sourcemaps/src/styles.css
+++ b/test/fixtures/inline-sourcemaps/src/styles.css
@@ -1,0 +1,3 @@
+body {
+  color: peachpuff;
+}

--- a/test/fixtures/no-sourcemaps/expected/styles.css
+++ b/test/fixtures/no-sourcemaps/expected/styles.css
@@ -1,0 +1,3 @@
+body {
+  color: peachpuff;
+}

--- a/test/fixtures/no-sourcemaps/src/styles.css
+++ b/test/fixtures/no-sourcemaps/src/styles.css
@@ -1,0 +1,3 @@
+body {
+  color: peachpuff;
+}

--- a/test/index.js
+++ b/test/index.js
@@ -48,5 +48,9 @@ describe('metalsmith-postcss', function () {
           done();
         });
     });
+
+    it('should rename sourcemap files');
+
+    it('should find and use previous sourcemaps');
   });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,24 @@
+var path = require('path');
+var fixture = path.resolve.bind(path, __dirname, 'fixtures');
+var assert = require('assert');
+var equal = require('assert-dir-equal');
+var Metalsmith = require('metalsmith');
+var postcss = require('..');
+
+describe('metalsmith-postcss', function () {
+
+  describe('sourcemaps', function () {
+
+    it('should not add sourcemaps at all', function (done) {
+      var metalsmith = Metalsmith(fixture('no-sourcemaps'));
+      metalsmith
+        .use(postcss([], {
+        }))
+        .build(function (err) {
+          if (err) return done(err);
+          equal(fixture('no-sourcemaps/build'), fixture('no-sourcemaps/expected'));
+          done();
+        });
+    });
+  });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -20,5 +20,33 @@ describe('metalsmith-postcss', function () {
           done();
         });
     });
+
+    it('should add inline sourcemaps', function (done) {
+      var metalsmith = Metalsmith(fixture('inline-sourcemaps'));
+      metalsmith
+        .use(postcss([], {
+          map: true
+        }))
+        .build(function (err) {
+          if (err) return done(err);
+          equal(fixture('inline-sourcemaps/build'), fixture('inline-sourcemaps/expected'));
+          done();
+        });
+    });
+
+    it('should add external sourcemap files', function (done) {
+      var metalsmith = Metalsmith(fixture('external-sourcemaps'));
+      metalsmith
+        .use(postcss([], {
+          map: {
+            inline: false
+          }
+        }))
+        .build(function (err) {
+          if (err) return done(err);
+          equal(fixture('external-sourcemaps/build'), fixture('external-sourcemaps/expected'));
+          done();
+        });
+    });
   });
 });


### PR DESCRIPTION
This pull request adds basic sourcemap support as requested in #6:
- Inline and external sourcemaps
- Tests
- Docs
