### PR TITLE
Improve README, add LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 AXA Versicherungen AG
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 metalsmith-postcss
 ===============
 
-A [PostCSS](https://github.com/postcss/postcss) plugin for Metalsmith.
+> A Metalsmith plugin that sends your CSS
+> through any [PostCSS](https://github.com/postcss/postcss) plugins.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-metalsmith-postcss
-===============
+# metalsmith-postcss
 
 > A Metalsmith plugin that sends your CSS
 > through any [PostCSS](https://github.com/postcss/postcss) plugins.
@@ -7,32 +6,21 @@ metalsmith-postcss
 ## Installation
 
 ```sh
-npm install --save metalsmith-postcss
+npm install metalsmith-postcss
 ```
 
 ## Getting Started
 
-If you haven't checked out [Metalsmith](http://metalsmith.io/) before, head over to their website and check out the
-documentation.
-
-## CLI Usage
-
-TBD
+If you haven't checked out [Metalsmith](http://metalsmith.io/) before,
+head over to their website and check out the documentation.
 
 ## JavaScript API
 
-If you are using the JS Api for Metalsmith, then you can require the module and add it to your
-`.use()` directives:
-
-```js
-var postcss = require('metalsmith-postcss');
-
-metalsmith.use(postcss(plugins));
-```
-
-## Plugins
-
-Pass your PostCSS plugins to `metalsmith-postcss` as follows:
+Using the JavaScript api for Metalsmith,
+just require the module and add it to your
+`.use()` directives. Here is an example using
+`postcss-pseudoelements` and `postcss-nested` to
+transform your source files.
 
 ```js
 var postcss = require('metalsmith-postcss');
@@ -40,5 +28,13 @@ var postcss = require('metalsmith-postcss');
 var pseudoelements = require('postcss-pseudoelements');
 var nested = require('postcss-nested');
 
-metalsmith.use(postcss([pseudoelements(), nested()]));
+metalsmith.use(postcss([
+  pseudoelements(),
+  nested()
+]));
 ```
+
+## CLI Usage
+
+It's currently *NOT* possible to use this plugin from your
+`metalsmith.json` file.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "metalsmith-postcss",
   "version": "3.0.0",
-  "description": "metalsmith postcss plugin",
+  "description": "A Metalsmith plugin that sends your CSS through any PostCSS plugins.",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -12,7 +12,9 @@
   },
   "keywords": [
     "metalsmith",
-    "postcss"
+    "postcss",
+    "css",
+    "preprocessor"
   ],
   "author": "AXA Versicherungen AG",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "metalsmith",
     "postcss"
   ],
-  "author": "Sven Tschui <sven.tschui@axa.ch>",
+  "author": "AXA Versicherungen AG",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/axa-ch/metalsmith-postcss/issues"


### PR DESCRIPTION
Some changes I made during the implementation of #8.
- Change description
- LICENSE file under _AXA Switzerland AG_
- Explicitly state that there's no support from `metalsmith.json`
