### PR TITLE
Support arrays as Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,23 @@ to transform your source files.
 }
 ```
 
+## Alternative plugin definition syntax
+
+Sometime in PostCSS, plugins need to be defined in a certain order and JavaScript
+Objects cannot guarantee the order of keys in an object. Therefore, you are able
+to specify PostCSS plugins using arrays (which can guarantee the order of loading).
+
+```js
+"metalsmith-postcss": {
+  "plugins": [
+    "postcss-pseudoelements",
+    ["postcss-nested", {
+      "some": "config"
+    }]
+  ]
+}
+```
+
 ## Sourcemaps
 
 This plugin doesn't generate sourcemaps by default. However, you

--- a/index.js
+++ b/index.js
@@ -13,13 +13,29 @@ function main(options) {
 
   // Require each plugin, pass it it’s options
   // and add it to the plugins array.
-  Object.keys(pluginsConfig).forEach(function(pluginName) {
-    var value = pluginsConfig[pluginName];
-    if (value === false) return;
-    var pluginOptions = value === true ? {} : value;
-    var plugin = require(pluginName);
-    plugins.push(plugin(pluginOptions));
-  });
+  if (Array.isArray(pluginsConfig)) {
+    pluginsConfig.forEach(function (plugin) {
+      var pkg;
+      var config = {};
+      if (typeof plugin === 'string') {
+        pkg = plugin;
+      } else {
+        pkg = plugin[0];
+        config = plugin[1];
+      }
+      if (config === false) {
+        return;
+      }
+      plugins.push(require(pkg)(config));
+    });
+  } else {
+    Object.keys(pluginsConfig).forEach(function (pluginName) {
+      var value = pluginsConfig[pluginName];
+      if (value === false) return;
+      var pluginOptions = value === true ? {} : value;
+      plugins.push(require(pluginName)(pluginOptions));
+    });
+  }
 
   var map = normalizeMapOptions(options.map);
 

--- a/test/index.js
+++ b/test/index.js
@@ -70,5 +70,20 @@ describe('metalsmith-postcss', function () {
           done();
         });
     });
+
+    it('should be able to use arrays as a way to define plugins', function (done) {
+      var metalsmith = Metalsmith(fixture('use-absolute-paths'));
+      metalsmith
+        .use(postcss({
+          plugins: [
+            ['postcss-import', {}]
+          ]
+        }))
+        .build(function (err) {
+          if (err) return done(err);
+          equal(fixture('use-absolute-paths/build'), fixture('use-absolute-paths/expected'));
+          done();
+        });
+    });
   });
 });


### PR DESCRIPTION
Sometimes, the order in which PostCSS plugins are loaded, matters, and objects can't guarantee order. So I added this to allow specifying plugins needed in a particular order.