### PR TITLE
Print usable error message when postcss fails

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,6 +65,10 @@ function main(options) {
         done();
       })
       .catch(function(error) {
+        // JSON.stringify on an actual error object yields 0 key/values
+        if (error instanceof Error) {
+          return done(error);
+        }
         done(new Error("Error during postcss processing: " + JSON.stringify(error)));
       });
 


### PR DESCRIPTION
When errors occur deep in post css they can be swallowed by the promise chain, often being left with:

![image](https://cloud.githubusercontent.com/assets/1443409/24082476/1a4f4142-0cbe-11e7-9679-4e0b2c3b08ec.png)

It now generates a (little ugly but) useful:

![image](https://cloud.githubusercontent.com/assets/1443409/24082557/956f16b2-0cbf-11e7-897b-866682e45383.png)

