### PR TITLE
Postcss 6 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "0.12"
   - "4.4.2"
-  - "5"
+  - "6"
 

--- a/package.json
+++ b/package.json
@@ -25,13 +25,13 @@
   "dependencies": {
     "minimatch": "^2.0.1",
     "path": "^0.12.7",
-    "postcss": "^5.0.4",
+    "postcss": "^5.0.4 || ^6.0.0",
     "promise": "^7.0.4"
   },
   "devDependencies": {
     "assert-dir-equal": "^1.0.1",
     "metalsmith": "^2.1.0",
     "mocha": "^2.3.3",
-    "postcss-import": "^8.0.2"
+    "postcss-import": "^8.0.2 || ^10.0.0"
   }
 }


### PR DESCRIPTION
I'm currently stuck on an old version of postcss because this module depends on version `^5`. It works fine with `^6` in my tests.

With this change, npm will install version 5 or 6, depending on which is compatible with the rest of the tree.