### PR TITLE
Fix bug preventing options to be passed to plugins

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ function main(options) {
       plugins.push(require(pluginsObject)({}));
     } else {
       Object.keys(pluginsObject).forEach(function (pluginName) {
-        var value = pluginsConfig[pluginName];
+        var value = pluginsObject[pluginName];
         if (value === false) return;
         var pluginOptions = value === true ? {} : value;
         plugins.push(require(pluginName)(pluginOptions));


### PR DESCRIPTION
This bug was introduced [here](https://github.com/axa-ch/metalsmith-postcss/commit/845d4375359abcede8659052d092d5a3c5bc3c72#diff-168726dbe96b3ce427e7fedce31bb0bc).